### PR TITLE
Fix Meta Tag

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html>
 	<head>
-		<meta name="go-import" content="gonum.org/v1 git https://github.com/gonum">
+		<meta name="go-import" content="gonum.org/v1/gonum git https://github.com/gonum/gonum">
+    	<meta name="go-import" content="gonum.org/v1/plot git https://github.com/gonum/plot">
 	</head>
 
 	<body>

--- a/index.html
+++ b/index.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="go-import" content="gonum.org/v1 git https://github.com/gonum">
+    <meta name="go-import" content="gonum.org/v1/gonum git https://github.com/gonum/gonum">
+    <meta name="go-import" content="gonum.org/v1/plot git https://github.com/gonum/plot">
     <title>Gonum | Welcome</title>
     <link rel="stylesheet" href="css/foundation.css" />
     <link rel="stylesheet" href="css/style.css" />


### PR DESCRIPTION
The Go tool documentation says that the import-prefix is the import path corresponding to the repository root. This means we need a separate meta-tag for each base repository.